### PR TITLE
Fix Typo in ADR-033 Document

### DIFF
--- a/docs/architecture/adr-033-protobuf-inter-module-comm.md
+++ b/docs/architecture/adr-033-protobuf-inter-module-comm.md
@@ -378,7 +378,7 @@ replacing `Keeper` interfaces altogether.
 
 * an alternative to keepers which can more easily lead to stable inter-module interfaces
 * proper inter-module OCAPs
-* improved module developer DevX, as commented on by several particpants on
+* improved module developer DevX, as commented on by several participants on
     [Architecture Review Call, Dec 3](https://hackmd.io/E0wxxOvRQ5qVmTf6N_k84Q)
 * lays the groundwork for what can be a greatly simplified `app.go`
 * router can be setup to enforce atomic transactions for module-to-module calls


### PR DESCRIPTION
# Pull Request: Fix Typo in ADR-033 Document

## Description
This pull request corrects a typo in the **`adr-033-protobuf-inter-module-comm.md`** file:
- Changed **"particpants"** to **"participants"** in the list under the "improved module developer DevX" section.

## Changes
- **File:** `docs/architecture/adr-033-protobuf-inter-module-comm.md`
  - Original: `as commented on by several particpants on`
  - Updated: `as commented on by several participants on`

## Motivation and Context
This change ensures accuracy and clarity in the documentation, improving readability and preventing confusion for developers reading the architecture decision record.

## Checklist
- [x] I have reviewed the changes for accuracy.
- [x] I have updated the documentation as needed.
- [x] My changes do not introduce new errors.

## Notes
- No functional changes to the codebase—this pull request only addresses a typo.
- Thank you for reviewing this pull request, and feedback is always welcome!

