### PR TITLE
typo fix unknown.go

### DIFF
--- a/x/tx/decode/unknown.go
+++ b/x/tx/decode/unknown.go
@@ -84,7 +84,7 @@ func RejectUnknownFields(bz []byte, desc protoreflect.MessageDescriptor, allowUn
 		}
 		// if a message descriptor is a placeholder resolve it using the injected resolver.
 		// this can happen when a descriptor has been registered in the
-		// "google.golang.org/protobuf" resgistry but not in "github.com/cosmos/gogoproto".
+		// "google.golang.org/protobuf" registry but not in "github.com/cosmos/gogoproto".
 		// fixes: https://github.com/cosmos/cosmos-sdk/issues/22574
 		if fieldMessage.IsPlaceholder() {
 			gogoDesc, err := resolver.FindDescriptorByName(fieldMessage.FullName())


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `unknown.go`**

## Description  
This pull request fixes a typo in the `unknown.go` file.

### Changes Made:
- **File Modified:** `unknown.go`
- **Summary of Changes:**  
  - Corrected the typo in the comment where "resgistry" was changed to "registry" for accuracy.

## Checklist  
- [x] Corrected the typo in the comment.
- [x] Verified the accuracy of the fix.

## Additional Notes  
This change addresses an issue related to the incorrect spelling of "registry," which could have led to confusion when reading the comments.

---

**Allow edits by maintainers:** [x]
